### PR TITLE
Button Action Events

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn main() {
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
         .init_resource::<MenuAssets>()
+        .add_event::<menu::ButtonAction>()
         .add_startup_system(global_setup.system())
         // AppState
         .insert_resource(State::new(AppState::MainMenu))
@@ -57,7 +58,22 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::MainMenu,
-            menu::button_interact.system(),
+            menu::button_interact.system().label("buttons"),
+        )
+        .on_state_update(
+            APPSTATES,
+            AppState::MainMenu,
+            menu::main_menu::button_exit_app.system().after("buttons"),
+        )
+        .on_state_update(
+            APPSTATES,
+            AppState::MainMenu,
+            menu::main_menu::button_enter_game.system().after("buttons"),
+        )
+        .on_state_update(
+            APPSTATES,
+            AppState::MainMenu,
+            menu::main_menu::button_open_settings_menu.system().after("buttons"),
         )
         .on_state_exit(
             APPSTATES,
@@ -73,7 +89,12 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::SettingsMenu,
-            menu::button_interact.system(),
+            menu::button_interact.system().label("buttons"),
+        )
+        .on_state_update(
+            APPSTATES,
+            AppState::SettingsMenu,
+            menu::settings::button_exit_settings_menu.system().after("buttons"),
         )
         .on_state_exit(
             APPSTATES,

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,9 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::MainMenu,
-            menu::main_menu::button_open_settings_menu.system().after("buttons"),
+            menu::main_menu::button_open_settings_menu
+                .system()
+                .after("buttons"),
         )
         .on_state_exit(
             APPSTATES,
@@ -94,7 +96,9 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::SettingsMenu,
-            menu::settings::button_exit_settings_menu.system().after("buttons"),
+            menu::settings::button_exit_settings_menu
+                .system()
+                .after("buttons"),
         )
         .on_state_exit(
             APPSTATES,

--- a/src/menu/main_menu.rs
+++ b/src/menu/main_menu.rs
@@ -1,10 +1,44 @@
+use bevy::app::AppExit;
 use bevy::prelude::*;
 
-use crate::menu::{ClickAction, MenuAssets};
+use crate::menu::{ButtonAction, MenuAssets};
 use crate::AppState;
 
 /// Marker for despawning when exiting `AppState::MainMenu`
 pub struct StateCleanup;
+
+pub fn button_exit_app(
+    mut actions: EventReader<ButtonAction>,
+    mut app_exit: ResMut<Events<AppExit>>,
+) {
+    for ev in actions.iter() {
+        if let ButtonAction::ExitApp = ev {
+            app_exit.send(AppExit);
+        }
+    }
+}
+
+pub fn button_enter_game(
+    mut actions: EventReader<ButtonAction>,
+    mut state: ResMut<State<AppState>>,
+) {
+    for ev in actions.iter() {
+        if let ButtonAction::EnterGame = ev {
+            state.set_next(AppState::Overworld).unwrap();
+        }
+    }
+}
+
+pub fn button_open_settings_menu(
+    mut actions: EventReader<ButtonAction>,
+    mut state: ResMut<State<AppState>>,
+) {
+    for ev in actions.iter() {
+        if let ButtonAction::OpenSettingsMenu = ev {
+            state.set_next(AppState::SettingsMenu).unwrap();
+        }
+    }
+}
 
 pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
     let button_style = Style {
@@ -98,7 +132,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::ChangeState(AppState::Overworld))
+                        .with(ButtonAction::EnterGame)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(
@@ -124,7 +158,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::ChangeState(AppState::SettingsMenu))
+                        .with(ButtonAction::OpenSettingsMenu)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(
@@ -141,7 +175,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::Exit)
+                        .with(ButtonAction::ExitApp)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -1,7 +1,4 @@
-use bevy::app::AppExit;
 use bevy::prelude::*;
-
-use crate::AppState;
 
 pub mod main_menu;
 pub mod settings;

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -6,6 +6,19 @@ use crate::AppState;
 pub mod main_menu;
 pub mod settings;
 
+/// Every logical action for which we can have a UI button
+///
+/// Add as a component to the respective button.
+///
+/// Implement functionality in systems that receive these as events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ButtonAction {
+    EnterGame,
+    ExitApp,
+    OpenSettingsMenu,
+    ExitSettingsMenu,
+}
+
 pub struct MenuAssets {
     button_normal: Handle<ColorMaterial>,
     button_hover: Handle<ColorMaterial>,
@@ -47,17 +60,11 @@ impl FromResources for MenuAssets {
     }
 }
 
-pub enum ClickAction {
-    ChangeState(AppState),
-    Exit,
-}
-
 pub fn button_interact(
-    mut state: ResMut<State<AppState>>,
-    mut app_exit: ResMut<Events<AppExit>>,
+    mut actions: ResMut<Events<ButtonAction>>,
     materials: Res<MenuAssets>,
     mut query: Query<
-        (&Interaction, &mut Handle<ColorMaterial>, &ClickAction),
+        (&Interaction, &mut Handle<ColorMaterial>, &ButtonAction),
         (Mutated<Interaction>, With<Button>),
     >,
 ) {
@@ -66,10 +73,7 @@ pub fn button_interact(
             Interaction::Clicked => {
                 *material = materials.button_active.clone();
 
-                match action {
-                    ClickAction::ChangeState(next) => state.set_next(*next).unwrap(),
-                    ClickAction::Exit => app_exit.send(AppExit),
-                }
+                actions.send(*action);
             }
             Interaction::Hovered => *material = materials.button_hover.clone(),
             Interaction::None => *material = materials.button_normal.clone(),

--- a/src/menu/settings.rs
+++ b/src/menu/settings.rs
@@ -1,10 +1,21 @@
 use bevy::prelude::*;
 
-use crate::menu::{ClickAction, MenuAssets};
+use crate::menu::{ButtonAction, MenuAssets};
 use crate::AppState;
 
 /// Marker for despawning when exiting `AppState::SettingsMenu`
 pub struct StateCleanup;
+
+pub fn button_exit_settings_menu(
+    mut actions: EventReader<ButtonAction>,
+    mut state: ResMut<State<AppState>>,
+) {
+    for ev in actions.iter() {
+        if let ButtonAction::ExitSettingsMenu = ev {
+            state.set_next(AppState::MainMenu).unwrap();
+        }
+    }
+}
 
 pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
     let button_style = Style {
@@ -121,7 +132,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::ChangeState(AppState::MainMenu))
+                        .with(ButtonAction::ExitSettingsMenu)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(


### PR DESCRIPTION
OK guys, so here is the pattern I came up with for more elegant (decentralized) button handling. Basically, just translate the button identifier component into an event.

The button identifier is added as a component to each button, to identify the action to be taken. This is the same as before.

The change is that now instead of matching on it in the `button_interact` system, it simply dispatches it as an event. The job of `button_interact` is now simply to handle the UI interactions and visual changes related to them. It does not concern itself with button behavior.

We can then simply make multiple granular systems for each button, each handling its respective button action events.

We need to ensure that all the various systems that implement the different button behaviors run after `button_interact`.

Also, for the button identifiers, I renamed `ClickAction` with `ButtonAction`, which should be an enum with a variant for each button we have. The variants should represent *logical behaviors*, not how it's implemented. Hence, I exploded `ChangeState` into different variants: `EnterGame`, `OpenSettingsMenu`, `ExitSettingsMenu`.

(what if we want to implement these differently in the future, not using a simple state change? let's not conflate interface and implementation)