### PR TITLE
Use System Chains to handle Buttons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,20 +57,23 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::MainMenu,
-            menu::button_interact::<menu::button::ExitApp>.system()
-                .chain(menu::main_menu::button_exit_app.system())
+            menu::button_interact::<menu::button::ExitApp>
+                .system()
+                .chain(menu::main_menu::button_exit_app.system()),
         )
         .on_state_update(
             APPSTATES,
             AppState::MainMenu,
-            menu::button_interact::<menu::button::EnterGame>.system()
-                .chain(menu::main_menu::button_enter_game.system())
+            menu::button_interact::<menu::button::EnterGame>
+                .system()
+                .chain(menu::main_menu::button_enter_game.system()),
         )
         .on_state_update(
             APPSTATES,
             AppState::MainMenu,
-            menu::button_interact::<menu::button::OpenSettingsMenu>.system()
-                .chain(menu::main_menu::button_open_settings_menu.system())
+            menu::button_interact::<menu::button::OpenSettingsMenu>
+                .system()
+                .chain(menu::main_menu::button_open_settings_menu.system()),
         )
         .on_state_exit(
             APPSTATES,
@@ -86,8 +89,9 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::SettingsMenu,
-            menu::button_interact::<menu::button::ExitSettingsMenu>.system()
-                .chain(menu::settings::button_exit_settings_menu.system())
+            menu::button_interact::<menu::button::ExitSettingsMenu>
+                .system()
+                .chain(menu::settings::button_exit_settings_menu.system()),
         )
         .on_state_exit(
             APPSTATES,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,20 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::MainMenu,
-            menu::button_interact.system(),
+            menu::button_interact::<menu::button::ExitApp>.system()
+                .chain(menu::main_menu::button_exit_app.system())
+        )
+        .on_state_update(
+            APPSTATES,
+            AppState::MainMenu,
+            menu::button_interact::<menu::button::EnterGame>.system()
+                .chain(menu::main_menu::button_enter_game.system())
+        )
+        .on_state_update(
+            APPSTATES,
+            AppState::MainMenu,
+            menu::button_interact::<menu::button::OpenSettingsMenu>.system()
+                .chain(menu::main_menu::button_open_settings_menu.system())
         )
         .on_state_exit(
             APPSTATES,
@@ -73,7 +86,8 @@ fn main() {
         .on_state_update(
             APPSTATES,
             AppState::SettingsMenu,
-            menu::button_interact.system(),
+            menu::button_interact::<menu::button::ExitSettingsMenu>.system()
+                .chain(menu::settings::button_exit_settings_menu.system())
         )
         .on_state_exit(
             APPSTATES,

--- a/src/menu/main_menu.rs
+++ b/src/menu/main_menu.rs
@@ -1,10 +1,38 @@
+use bevy::app::AppExit;
 use bevy::prelude::*;
 
-use crate::menu::{ClickAction, MenuAssets};
+use crate::menu::{button, MenuAssets};
 use crate::AppState;
 
 /// Marker for despawning when exiting `AppState::MainMenu`
 pub struct StateCleanup;
+
+pub fn button_exit_app(
+    In(clicked): In<bool>,
+    mut app_exit: ResMut<Events<AppExit>>,
+) {
+    if clicked {
+        app_exit.send(AppExit);
+    }
+}
+
+pub fn button_enter_game(
+    In(clicked): In<bool>,
+    mut state: ResMut<State<AppState>>,
+) {
+    if clicked {
+        state.set_next(AppState::Overworld).unwrap();
+    }
+}
+
+pub fn button_open_settings_menu(
+    In(clicked): In<bool>,
+    mut state: ResMut<State<AppState>>,
+) {
+    if clicked {
+        state.set_next(AppState::SettingsMenu).unwrap();
+    }
+}
 
 pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
     let button_style = Style {
@@ -98,7 +126,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::ChangeState(AppState::Overworld))
+                        .with(button::EnterGame)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(
@@ -124,7 +152,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::ChangeState(AppState::SettingsMenu))
+                        .with(button::OpenSettingsMenu)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(
@@ -141,7 +169,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::Exit)
+                        .with(button::ExitApp)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(

--- a/src/menu/main_menu.rs
+++ b/src/menu/main_menu.rs
@@ -7,28 +7,19 @@ use crate::AppState;
 /// Marker for despawning when exiting `AppState::MainMenu`
 pub struct StateCleanup;
 
-pub fn button_exit_app(
-    In(clicked): In<bool>,
-    mut app_exit: ResMut<Events<AppExit>>,
-) {
+pub fn button_exit_app(In(clicked): In<bool>, mut app_exit: ResMut<Events<AppExit>>) {
     if clicked {
         app_exit.send(AppExit);
     }
 }
 
-pub fn button_enter_game(
-    In(clicked): In<bool>,
-    mut state: ResMut<State<AppState>>,
-) {
+pub fn button_enter_game(In(clicked): In<bool>, mut state: ResMut<State<AppState>>) {
     if clicked {
         state.set_next(AppState::Overworld).unwrap();
     }
 }
 
-pub fn button_open_settings_menu(
-    In(clicked): In<bool>,
-    mut state: ResMut<State<AppState>>,
-) {
+pub fn button_open_settings_menu(In(clicked): In<bool>, mut state: ResMut<State<AppState>>) {
     if clicked {
         state.set_next(AppState::SettingsMenu).unwrap();
     }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -1,10 +1,17 @@
-use bevy::app::AppExit;
 use bevy::prelude::*;
-
-use crate::AppState;
 
 pub mod main_menu;
 pub mod settings;
+
+/// Every logical action for which we can have a UI button
+///
+/// Use as marker components to identify the buttons.
+pub mod button {
+    pub struct EnterGame;
+    pub struct ExitApp;
+    pub struct OpenSettingsMenu;
+    pub struct ExitSettingsMenu;
+}
 
 pub struct MenuAssets {
     button_normal: Handle<ColorMaterial>,
@@ -47,32 +54,25 @@ impl FromResources for MenuAssets {
     }
 }
 
-pub enum ClickAction {
-    ChangeState(AppState),
-    Exit,
-}
-
-pub fn button_interact(
-    mut state: ResMut<State<AppState>>,
-    mut app_exit: ResMut<Events<AppExit>>,
+pub fn button_interact<B: Component>(
     materials: Res<MenuAssets>,
     mut query: Query<
-        (&Interaction, &mut Handle<ColorMaterial>, &ClickAction),
-        (Mutated<Interaction>, With<Button>),
+        (&Interaction, &mut Handle<ColorMaterial>),
+        (Mutated<Interaction>, With<Button>, With<B>),
     >,
-) {
-    for (interaction, mut material, action) in query.iter_mut() {
+) -> bool {
+    let mut clicked = false;
+
+    for (interaction, mut material) in query.iter_mut() {
         match interaction {
             Interaction::Clicked => {
                 *material = materials.button_active.clone();
-
-                match action {
-                    ClickAction::ChangeState(next) => state.set_next(*next).unwrap(),
-                    ClickAction::Exit => app_exit.send(AppExit),
-                }
+                clicked = true;
             }
             Interaction::Hovered => *material = materials.button_hover.clone(),
             Interaction::None => *material = materials.button_normal.clone(),
         }
     }
+
+    clicked
 }

--- a/src/menu/settings.rs
+++ b/src/menu/settings.rs
@@ -1,10 +1,19 @@
 use bevy::prelude::*;
 
-use crate::menu::{ClickAction, MenuAssets};
+use crate::menu::{button, MenuAssets};
 use crate::AppState;
 
 /// Marker for despawning when exiting `AppState::SettingsMenu`
 pub struct StateCleanup;
+
+pub fn button_exit_settings_menu(
+    In(clicked): In<bool>,
+    mut state: ResMut<State<AppState>>,
+) {
+    if clicked {
+        state.set_next(AppState::MainMenu).unwrap();
+    }
+}
 
 pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
     let button_style = Style {
@@ -121,7 +130,7 @@ pub fn setup(commands: &mut Commands, assets: Res<MenuAssets>) {
                             style: button_style.clone(),
                             ..Default::default()
                         })
-                        .with(ClickAction::ChangeState(AppState::MainMenu))
+                        .with(button::ExitSettingsMenu)
                         .with_children(|button| {
                             button.spawn(TextBundle {
                                 text: Text::with_section(

--- a/src/menu/settings.rs
+++ b/src/menu/settings.rs
@@ -6,10 +6,7 @@ use crate::AppState;
 /// Marker for despawning when exiting `AppState::SettingsMenu`
 pub struct StateCleanup;
 
-pub fn button_exit_settings_menu(
-    In(clicked): In<bool>,
-    mut state: ResMut<State<AppState>>,
-) {
+pub fn button_exit_settings_menu(In(clicked): In<bool>, mut state: ResMut<State<AppState>>) {
     if clicked {
         state.set_next(AppState::MainMenu).unwrap();
     }


### PR DESCRIPTION
Alternative to #11

This allows for cleaner code with less overhead.

This uses the Rust type system to handle buttons elegantly.

Instead of an enum, we use marker component structs to identify buttons.

The `button_interact` system is generic over the marker component type, so it can be added multiple times for different button types. Since the different monomorphizations access different components/archetypes, this means they should all be able to run in parallel.

It outputs a bool, which is true when the button is pressed.

It is *chained* with a handler system, which is where you implement the actual behavior of the button. It receives the bool as an input, to know if the button was clicked.