### PR TITLE
Persistent user config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,8 +3128,8 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "directories",
+ "ron",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efa60d2eadd8b12a996add391db32bd1153eac697ba4869660c0016353611426"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
  "once_cell",
  "version_check",
 ]
@@ -146,6 +146,12 @@ checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
@@ -423,6 +429,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_math",
  "bevy_utils",
+ "serde",
 ]
 
 [[package]]
@@ -679,7 +686,7 @@ version = "0.4.0"
 source = "git+https://github.com/bevyengine/bevy.git?rev=f8292ccf7ef99b254e936329de9dd7e079760e55#f8292ccf7ef99b254e936329de9dd7e079760e55"
 dependencies = [
  "ahash 0.7.0",
- "getrandom",
+ "getrandom 0.2.2",
  "instant",
  "tracing",
  "uuid",
@@ -773,6 +780,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block"
@@ -975,6 +993,12 @@ name = "const_fn"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -1249,6 +1273,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,7 +1388,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "winapi 0.3.9",
 ]
 
@@ -1473,6 +1517,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
@@ -1480,7 +1535,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2574,7 +2629,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2714,7 +2769,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -2749,11 +2804,28 @@ checksum = "e509b8eba9ca1884760ad1e2161cece724d4fd2b4cb47ddc01706920c6500cd7"
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
 ]
 
 [[package]]
@@ -2824,6 +2896,18 @@ dependencies = [
  "base64",
  "bitflags",
  "serde",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3043,6 +3127,9 @@ name = "sotora"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "directories",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3480,7 +3567,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
  "serde",
 ]
 
@@ -3524,6 +3611,12 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,14 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+directories = "3.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dependencies.bevy]
 git = "https://github.com/bevyengine/bevy.git"
 rev = "f8292ccf7ef99b254e936329de9dd7e079760e55"
+features = ["serialize"]
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 directories = "3.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+ron = "0.6"
 
 [dependencies.bevy]
 git = "https://github.com/bevyengine/bevy.git"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
+use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::prelude::*;
 
 use crate::menu::MenuAssets;
-use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
+use crate::user_config::{KeyBinds, UserConfig};
 
 mod menu;
 mod overworld;
+mod user_config;
 
 /// Despawn all entities with given component
 ///
@@ -43,6 +45,7 @@ fn main() {
         })
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
+        .insert_resource(KeyBinds::load())
         .init_resource::<MenuAssets>()
         .add_startup_system(global_setup.system())
         // AppState

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -18,9 +18,9 @@ pub struct MenuAssets {
     font_light: Handle<Font>,
     font_light_italic: Handle<Font>,
     font_regular: Handle<Font>,
-    font_regular_italic: Handle<Font>,
+    //font_regular_italic: Handle<Font>,
     font_bold: Handle<Font>,
-    font_bold_italic: Handle<Font>,
+    //font_bold_italic: Handle<Font>,
 }
 
 impl FromResources for MenuAssets {
@@ -40,9 +40,9 @@ impl FromResources for MenuAssets {
             font_light: assets.load("fonts/sansation/Sansation-Light.ttf"),
             font_light_italic: assets.load("fonts/sansation/Sansation-LightItalic.ttf"),
             font_regular: assets.load("fonts/sansation/Sansation-Regular.ttf"),
-            font_regular_italic: assets.load("fonts/sansation/Sansation-Italic.ttf"),
+            //font_regular_italic: assets.load("fonts/sansation/Sansation-Italic.ttf"),
             font_bold: assets.load("fonts/sansation/Sansation-Bold.ttf"),
-            font_bold_italic: assets.load("fonts/sansation/Sansation-BoldItalic.ttf"),
+            //font_bold_italic: assets.load("fonts/sansation/Sansation-BoldItalic.ttf"),
         }
     }
 }

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -76,9 +76,9 @@ pub struct MenuAssets {
     font_light: Handle<Font>,
     font_light_italic: Handle<Font>,
     font_regular: Handle<Font>,
-    //font_regular_italic: Handle<Font>,
+    font_regular_italic: Handle<Font>,
     font_bold: Handle<Font>,
-    //font_bold_italic: Handle<Font>,
+    font_bold_italic: Handle<Font>,
 }
 
 impl FromResources for MenuAssets {
@@ -98,9 +98,9 @@ impl FromResources for MenuAssets {
             font_light: assets.load("fonts/sansation/Sansation-Light.ttf"),
             font_light_italic: assets.load("fonts/sansation/Sansation-LightItalic.ttf"),
             font_regular: assets.load("fonts/sansation/Sansation-Regular.ttf"),
-            //font_regular_italic: assets.load("fonts/sansation/Sansation-Italic.ttf"),
+            font_regular_italic: assets.load("fonts/sansation/Sansation-Italic.ttf"),
             font_bold: assets.load("fonts/sansation/Sansation-Bold.ttf"),
-            //font_bold_italic: assets.load("fonts/sansation/Sansation-BoldItalic.ttf"),
+            font_bold_italic: assets.load("fonts/sansation/Sansation-BoldItalic.ttf"),
         }
     }
 }

--- a/src/overworld/player.rs
+++ b/src/overworld/player.rs
@@ -1,11 +1,14 @@
 use bevy::prelude::*;
 
+use crate::user_config::KeyBinds;
+
 pub struct Player {
     pub speed: f32,
 }
 
 pub fn move_player(
     input: Res<Input<KeyCode>>,
+    keybinds: Res<KeyBinds>,
     mut query: Query<(&mut Transform, &Player)>,
     time: Res<Time>,
 ) {
@@ -13,16 +16,17 @@ pub fn move_player(
         let forward = transform.forward();
         let left = forward.cross(Vec3::unit_y());
         let delta = time.delta_seconds() * player.speed;
-        if input.pressed(KeyCode::W) {
+
+        if input.pressed(keybinds.move_forward) {
             transform.translation += forward * delta;
         }
-        if input.pressed(KeyCode::S) {
+        if input.pressed(keybinds.move_backward) {
             transform.translation -= forward * delta;
         }
-        if input.pressed(KeyCode::A) {
+        if input.pressed(keybinds.move_left) {
             transform.translation -= left * delta;
         }
-        if input.pressed(KeyCode::D) {
+        if input.pressed(keybinds.move_right) {
             transform.translation += left * delta;
         }
     }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -1,13 +1,14 @@
-use std::fs::{File, OpenOptions};
-use std::io::{BufReader, BufWriter, Error, ErrorKind};
-use std::path::{Path, PathBuf};
-use std::{fs, io};
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::{BufReader, BufWriter, ErrorKind};
+use std::path::PathBuf;
 
 use bevy::prelude::*;
 use directories::ProjectDirs;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+/// Configurable key bindings
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct KeyBinds {

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -68,7 +68,7 @@ fn load_user_config<C: UserConfig>() -> C {
             serde_json::from_reader(reader).expect("Could not read config file")
         }
         Err(e) if e.kind() == ErrorKind::NotFound => Default::default(),
-        Err(e) => panic!(e),
+        Err(e) => panic!("{}", e),
     }
 }
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -1,0 +1,95 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, BufWriter, Error, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+use bevy::prelude::*;
+use directories::ProjectDirs;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct KeyBinds {
+    pub move_forward: KeyCode,
+    pub move_left: KeyCode,
+    pub move_backward: KeyCode,
+    pub move_right: KeyCode,
+}
+
+impl Default for KeyBinds {
+    fn default() -> Self {
+        KeyBinds {
+            move_forward: KeyCode::W,
+            move_left: KeyCode::A,
+            move_backward: KeyCode::S,
+            move_right: KeyCode::D,
+        }
+    }
+}
+
+impl UserConfig for KeyBinds {
+    const FILE_NAME: &'static str = "key_binds";
+}
+
+/// A configuration object that is persisted to disk as a JSON file
+pub trait UserConfig: Serialize + DeserializeOwned + Default {
+    /// Unique filename to store in the user data directory
+    ///
+    /// Should not include a file extension.
+    const FILE_NAME: &'static str;
+
+    /// Load the config data
+    ///
+    /// If no file exists yet, this will create a new config file with the
+    /// `Default::default()` values
+    fn load() -> Self {
+        let config = load_user_config::<Self>();
+        config.save();
+        config
+    }
+
+    /// Saves the config data
+    fn save(&self) {
+        save_user_config(self);
+    }
+}
+
+/// Loads the user config from disk, or returns the default values if the file does not exist
+fn load_user_config<C: UserConfig>() -> C {
+    let file = OpenOptions::new()
+        .read(true)
+        .open(get_user_config_dir().join(format!("{}.json", C::FILE_NAME)));
+
+    match file {
+        Ok(file) => {
+            let reader = BufReader::new(file);
+            serde_json::from_reader(reader).expect("Could not read config file")
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => Default::default(),
+        Err(e) => panic!(e),
+    }
+}
+
+/// Saves the user config data to disk, overwriting any existing config files
+fn save_user_config<C: UserConfig>(data: &C) {
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(get_user_config_dir().join(format!("{}.json", C::FILE_NAME)))
+        .expect("Could not open user config file for writing");
+
+    let writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(writer, data).expect("Could not write config file");
+}
+
+/// Gets the platform-specific user config directory
+fn get_user_config_dir() -> PathBuf {
+    let dirs = ProjectDirs::from("", "bevy-community", "sotora")
+        .expect("Could not access user config dirs");
+
+    fs::create_dir_all(dirs.config_dir()).expect("Could not create user config directory");
+
+    dirs.config_dir().to_owned()
+}


### PR DESCRIPTION
Key bindings are now loaded from a file instead of hardcoded. Azerty gang rise up!

- Added a `UserConfig` trait and some fns that contain all of the functionality to save and load user config files (using Serde).
- Implemented said `UserConfig` trait on a `KeyBinds` struct to (a) showcase the trait in action and (b) allow me to play the game on my azerty keyboard without breaking my fingers.

No key rebinding UI (yet), but the file is saved in the default system config dir (see [`ProjectDirs::config_dir()`](https://docs.rs/directories/3.0.1/directories/struct.ProjectDirs.html#method.config_dir)).