### PR TITLE
Added CI caching, rearranged the steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
                       ~/.cargo/registry
                       ~/.cargo/git
                       target
+                  ####### TO PURGE CACHE: increment this number ↓↓↓
                   key: ${{ runner.os }}-${{ matrix.toolchain }}-V0-${{ hashFiles('**/Cargo.lock') }}
 
             - name: Install alsa and udev (if Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,18 @@ jobs:
                   components: rustfmt, clippy
                   override: true
 
+            - name: Cache target dir
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      target
+                  key: ${{ runner.os }}-${{ matrix.toolchain }}-V0-${{ hashFiles('**/Cargo.lock') }}
+
             - name: Install alsa and udev (if Linux)
               run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
               if: runner.os == 'linux'
-
-            - name: Check formatting
-              run: cargo fmt --all -- --check
-              if: runner.os == 'linux' && matrix.toolchain == 'stable'
-
-            # type complexity must be ignored because we use huge templates for queries
-            # -A clippy::manual-strip: strip_prefix support was added in 1.45. we want to support earlier rust versions
-            - name: Clippy
-              run: cargo clippy --all-targets --all-features -- -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
-              if: runner.os == 'linux' && matrix.toolchain == 'stable'
 
             #- name: Build & run tests
             #  run: cargo test --workspace
@@ -51,3 +50,13 @@ jobs:
               env:
                   CARGO_INCREMENTAL: 0
                   RUSTFLAGS: "-C debuginfo=0 -D warnings -A dead-code"
+
+            - name: Check formatting
+              run: cargo fmt --all -- --check
+              if: runner.os == 'linux' && matrix.toolchain == 'stable'
+
+            # type complexity must be ignored because we use huge templates for queries
+            # -A clippy::manual-strip: strip_prefix support was added in 1.45. we want to support earlier rust versions
+            - name: Clippy
+              run: cargo clippy --all-targets --all-features -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
+              if: runner.os == 'linux' && matrix.toolchain == 'stable'


### PR DESCRIPTION
This *should* speed up CI for all PRs using the same Cargo.lock (minus the first one to use a new lock, naturally). It should all be automatic, but if something tweaks over and we need to purge the cache there is a comment in the workflow config on how to do that: increment the "version" number in the cache key. It's stupid, but there is no official way to do that, so everyone has to resort to some sort of workaround.