### PR TITLE
CI cache fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Get Rust toolchain
       - uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          components: rustfmt, clippy
           override: true
 
       - name: Retrieve cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     branches: [master]
 
@@ -11,7 +11,7 @@ env:
 
 jobs:
   rustfmt-clippy:
-    name: Clippy and formatting
+    name: Formatting and Clippy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,7 +33,11 @@ jobs:
             ~/.cargo/git
             target
           # TO PURGE CACHE: increment this ↓↓↓ number
-          key: Linux-stable-rustmft-clippy-V2-${{ hashFiles('**/Cargo.lock') }}
+          key: Linux-stable-rustmft-clippy-V3-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        if: always()
+        run: cargo fmt --all -- --check
 
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
@@ -42,21 +46,17 @@ jobs:
         if: always()
         run: cargo clippy --workspace --all-targets --all-features -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
 
-      - name: Check formatting
-        if: always()
-        run: cargo fmt --all -- --check
-
   build:
     name: Build
     strategy:
       matrix:
-        toolchain: [stable, nightly]
+        toolchain: [stable, beta]
         os: [windows-latest, ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
-            toolchain: nightly
+            toolchain: beta
           - os: windows-latest
-            toolchain: nightly
+            toolchain: beta
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
             ~/.cargo/git
             target
           ####### TO PURGE CACHE: increment this number ↓↓↓
-          key: ${{ runner.os }}-${{ matrix.toolchain }}-V2-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-V3-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install alsa and udev (if Linux)
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
                       ~/.cargo/git
                       target
                   ####### TO PURGE CACHE: increment this number ↓↓↓
-                  key: ${{ runner.os }}-${{ matrix.toolchain }}-V0-${{ hashFiles('**/Cargo.lock') }}
+                  key: ${{ runner.os }}-${{ matrix.toolchain }}-V1-${{ hashFiles('**/Cargo.lock') }}
 
             - name: Install alsa and udev (if Linux)
               run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
@@ -45,7 +45,7 @@ jobs:
             #- name: Build & run tests
             #  run: cargo test --workspace
             - name: Build
-              run: cargo build --workspace
+              run: cargo build --all-targets --all-features --workspace
               env:
                   CARGO_INCREMENTAL: 0
                   RUSTFLAGS: "-C debuginfo=0 -D warnings -A dead-code"
@@ -57,5 +57,5 @@ jobs:
             # type complexity must be ignored because we use huge templates for queries
             # -A clippy::manual-strip: strip_prefix support was added in 1.45. we want to support earlier rust versions
             - name: Clippy
-              run: cargo clippy --all-targets --all-features -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
+              run: cargo clippy --all-targets --all-features --workspace -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
               if: runner.os == 'linux' && matrix.toolchain == 'stable'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
 
   build:
-    name: Build
+    name: Build and test
     strategy:
       matrix:
         toolchain: [stable, beta]
@@ -59,10 +59,11 @@ jobs:
             toolchain: beta
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Get Rust toolchain
-      - uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
@@ -84,6 +85,12 @@ jobs:
 
       - name: Build
         run: cargo build --workspace --all-targets --all-features
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings -A dead-code"
+
+      - name: Test
+        run: cargo test --workspace --all-targets --all-features
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings -A dead-code"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,61 +1,89 @@
 name: CI
 
 on:
-    pull_request:
-        branches: [master]
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [master]
 
 env:
-    CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: always
 
 jobs:
-    build:
-        strategy:
-            matrix:
-                toolchain: [stable, nightly]
-                os: [windows-latest, ubuntu-latest, macos-latest]
-                exclude:
-                    - os: macos-latest
-                      toolchain: nightly
-                    - os: windows-latest
-                      toolchain: nightly
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v2
+  rustfmt-clippy:
+    name: Clippy and formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: ${{ matrix.toolchain }}
-                  components: rustfmt, clippy
-                  override: true
+      - name: Get Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
 
-            - name: Cache target dir
-              uses: actions/cache@v2
-              with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                      target
-                  ####### TO PURGE CACHE: increment this number ↓↓↓
-                  key: ${{ runner.os }}-${{ matrix.toolchain }}-V1-${{ hashFiles('**/Cargo.lock') }}
+      - name: Retrieve cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # TO PURGE CACHE: increment this ↓↓↓ number
+          key: Linux-stable-rustmft-clippy-V2-${{ hashFiles('**/Cargo.lock') }}
 
-            - name: Install alsa and udev (if Linux)
-              run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-              if: runner.os == 'linux'
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
 
-            #- name: Build & run tests
-            #  run: cargo test --workspace
-            - name: Build
-              run: cargo build --all-targets --all-features --workspace
-              env:
-                  CARGO_INCREMENTAL: 0
-                  RUSTFLAGS: "-C debuginfo=0 -D warnings -A dead-code"
+      - name: Clippy
+        if: always()
+        run: cargo clippy --workspace --all-targets --all-features -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
 
-            - name: Check formatting
-              run: cargo fmt --all -- --check
-              if: runner.os == 'linux' && matrix.toolchain == 'stable'
+      - name: Check formatting
+        if: always()
+        run: cargo fmt --all -- --check
 
-            # type complexity must be ignored because we use huge templates for queries
-            # -A clippy::manual-strip: strip_prefix support was added in 1.45. we want to support earlier rust versions
-            - name: Clippy
-              run: cargo clippy --all-targets --all-features --workspace -- --no-deps -D warnings -A clippy::type_complexity -A clippy::manual-strip -A dead-code
-              if: runner.os == 'linux' && matrix.toolchain == 'stable'
+  build:
+    name: Build
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        exclude:
+          - os: macos-latest
+            toolchain: nightly
+          - os: windows-latest
+            toolchain: nightly
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Rust toolchain
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
+          override: true
+
+      - name: Retrieve cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          ####### TO PURGE CACHE: increment this number ↓↓↓
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-V2-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install alsa and udev (if Linux)
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        if: runner.os == 'linux'
+
+      - name: Build
+        run: cargo build --workspace --all-targets --all-features
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings -A dead-code"


### PR DESCRIPTION
Split formatting+clippy into its own job with its own cache. Changed nightly to beta to avoid 15+ minute CI runs every new nightly. Returned run-on-push (apparently those are needed to prevent multiple PRs in short succession leaving the repo in an invalid state). Also changed the formatting of the workflow file to default YAML format: 2-space indents.