### PR TITLE
Interactable names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
 name = "sotora"
 version = "0.1.0"
 dependencies = [
+ "ab_glyph",
  "bevy",
  "directories",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 directories = "3.0"
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.6"
+ab_glyph = "0.2.9"
 
 [dependencies.bevy]
 git = "https://github.com/bevyengine/bevy.git"

--- a/src/battle/camera.rs
+++ b/src/battle/camera.rs
@@ -1,9 +1,10 @@
 use bevy::{input::mouse::MouseMotion, prelude::*};
 
-pub struct Camera;
+pub struct CameraRoot;
+pub struct CameraObject;
 
 pub fn rotate_camera(
-    mut query: Query<&mut Transform, With<Camera>>,
+    mut query: Query<&mut Transform, With<CameraRoot>>,
     mut mouse_events: EventReader<MouseMotion>,
     window: Res<WindowDescriptor>,
 ) {

--- a/src/battle/mod.rs
+++ b/src/battle/mod.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use self::camera::Camera;
+use self::camera::{CameraObject, CameraRoot};
 
 use crate::hud_area_label::HudAreaLabel;
 use crate::AppState;
@@ -71,7 +71,7 @@ fn spawn_camera(commands: &mut Commands) -> Entity {
         .spawn(())
         .with(Transform::default())
         .with(GlobalTransform::default())
-        .with(Camera)
+        .with(CameraRoot)
         .current_entity()
         .unwrap();
 
@@ -80,6 +80,7 @@ fn spawn_camera(commands: &mut Commands) -> Entity {
             transform,
             ..Default::default()
         })
+        .with(CameraObject)
         .with(StateCleanup)
         .current_entity()
         .unwrap();

--- a/src/overworld/camera.rs
+++ b/src/overworld/camera.rs
@@ -1,9 +1,10 @@
 use bevy::{input::mouse::MouseMotion, prelude::*};
 
-pub struct Camera;
+pub struct CameraRoot;
+pub struct CameraObject;
 
 pub fn rotate_camera(
-    mut query: Query<&mut Transform, With<Camera>>,
+    mut query: Query<&mut Transform, With<CameraRoot>>,
     mut mouse_events: EventReader<MouseMotion>,
     window: Res<WindowDescriptor>,
 ) {

--- a/src/overworld/mod.rs
+++ b/src/overworld/mod.rs
@@ -162,7 +162,7 @@ fn spawn_interactables(
             ..Default::default()
         })
         .with(BattleStarter)
-        .with(NameTag("Battle".to_string()))
+        .with(NameTag::new("Battle".to_string()))
         .with(StateCleanup);
 
     let ferris_handle = asset_server.load("sprites/ferris-happy.png");
@@ -173,7 +173,7 @@ fn spawn_interactables(
             transform: Transform::from_translation(Vec3::new(-5., 1.0, 5.)),
             ..Default::default()
         })
-        .with(NameTag("Ferris".to_string()))
+        .with(NameTag::new("Ferris".to_string()))
         .with(DialogStarter {
             npc_name: "Ferris".to_string(),
             sprite: c_materials.add(ferris_handle.into()),

--- a/src/overworld/name_tags.rs
+++ b/src/overworld/name_tags.rs
@@ -1,0 +1,178 @@
+use crate::overworld::CameraObject;
+use crate::overworld::StateCleanup;
+use crate::UiAssets;
+use bevy::prelude::*;
+
+pub struct NameTag(pub String);
+
+pub struct NameTagSprite(Entity);
+
+pub fn spawn_name_tag_sprite(
+    commands: &mut Commands,
+    assets: Res<UiAssets>,
+    fonts: Res<Assets<Font>>,
+    mut textures: ResMut<Assets<Texture>>,
+    mut color_materials: ResMut<Assets<ColorMaterial>>,
+    query: Query<(Entity, &NameTag), Added<NameTag>>,
+) {
+    if let Some(font) = fonts.get(assets.font_regular.clone()) {
+        for (entity, name_tag) in query.iter() {
+            let text = font.render_text(&name_tag.0, Color::WHITE, 30., 100, 100);
+            let text_handle = textures.add(text);
+
+            commands
+                .spawn(SpriteBundle {
+                    material: color_materials.add(text_handle.into()),
+
+                    sprite: Sprite {
+                        size: Vec2::new(1.0, 1.0),
+                        ..Default::default()
+                    },
+                    transform: Transform::from_scale(Vec3::new(-0.03, 0.03, 0.03)),
+                    ..Default::default()
+                })
+                .with(StateCleanup)
+                .with(NameTagSprite(entity));
+        }
+    }
+}
+
+pub fn move_name_tag_and_rotate(
+    mut name_tags: Query<(&mut Transform, &NameTagSprite)>,
+    tag_holders: Query<&Transform, With<NameTag>>,
+    camera_query: Query<&GlobalTransform, With<CameraObject>>,
+) {
+    let camera_transform = camera_query.iter().next().unwrap();
+
+    for (mut transform, tag) in name_tags.iter_mut() {
+        let holder = if let Ok(holder) = tag_holders.get(tag.0) {
+            holder.translation
+        } else {
+            continue;
+        };
+
+        transform.look_at(camera_transform.translation, Vec3::unit_y());
+        transform.translation = Vec3::unit_y() + holder;
+    }
+}
+
+use ab_glyph::{self, Glyph, Point, ScaleFont};
+use bevy::render::texture::{Extent3d, TextureDimension, TextureFormat};
+
+pub trait FontExtension {
+    fn render_text(
+        &self,
+        text: &str,
+        color: Color,
+        font_size: f32,
+        width: usize,
+        height: usize,
+    ) -> Texture;
+}
+
+impl FontExtension for Font {
+    fn render_text(
+        &self,
+        text: &str,
+        color: Color,
+        font_size: f32,
+        width: usize,
+        height: usize,
+    ) -> Texture {
+        let scale = ab_glyph::PxScale::from(font_size);
+
+        let scaled_font = ab_glyph::Font::as_scaled(&self.font, scale);
+
+        let mut glyphs = Vec::new();
+        layout_paragraph(
+            scaled_font,
+            ab_glyph::point(0.0, 0.0),
+            width as f32,
+            text,
+            &mut glyphs,
+        );
+
+        let color_u8 = [
+            (color.r() * 255.0) as u8,
+            (color.g() * 255.0) as u8,
+            (color.b() * 255.0) as u8,
+        ];
+
+        let mut alpha = vec![0.0; width * height];
+        for glyph in glyphs {
+            if let Some(outlined) = scaled_font.outline_glyph(glyph) {
+                let bounds = outlined.px_bounds();
+                // Draw the glyph into the image per-pixel by using the draw closure
+                outlined.draw(|x, y, v| {
+                    // Offset the position by the glyph bounding box
+                    // Turn the coverage into an alpha value (blended with any previous)
+                    let offset_x = x as usize + bounds.min.x as usize;
+                    let offset_y = y as usize + bounds.min.y as usize;
+                    if offset_x >= width || offset_y >= height {
+                        return;
+                    }
+                    alpha[offset_y * width + offset_x] = v;
+                });
+            }
+        }
+
+        Texture::new(
+            Extent3d::new(width as u32, height as u32, 1),
+            TextureDimension::D2,
+            alpha
+                .iter()
+                .map(|a| {
+                    vec![
+                        color_u8[0],
+                        color_u8[1],
+                        color_u8[2],
+                        (color.a() * a * 255.0) as u8,
+                    ]
+                })
+                .flatten()
+                .collect::<Vec<u8>>(),
+            TextureFormat::Rgba8UnormSrgb,
+        )
+    }
+}
+
+// TODO Move to another file
+fn layout_paragraph<F, SF>(
+    font: SF,
+    position: Point,
+    max_width: f32,
+    text: &str,
+    target: &mut Vec<Glyph>,
+) where
+    F: ab_glyph::Font,
+    SF: ScaleFont<F>,
+{
+    let v_advance = font.height() + font.line_gap();
+    let mut caret = position + ab_glyph::point(0.0, font.ascent());
+    let mut last_glyph: Option<Glyph> = None;
+    for c in text.chars() {
+        if c.is_control() {
+            if c == '\n' {
+                caret = ab_glyph::point(position.x, caret.y + v_advance);
+                last_glyph = None;
+            }
+            continue;
+        }
+        let mut glyph = font.scaled_glyph(c);
+        if let Some(previous) = last_glyph.take() {
+            caret.x += font.kern(previous.id, glyph.id);
+        }
+        glyph.position = caret;
+
+        last_glyph = Some(glyph.clone());
+        caret.x += font.h_advance(glyph.id);
+
+        if !c.is_whitespace() && caret.x > position.x + max_width {
+            caret = ab_glyph::point(position.x, caret.y + v_advance);
+            glyph.position = caret;
+            last_glyph = None;
+        }
+
+        target.push(glyph);
+    }
+}


### PR DESCRIPTION
This PR adds a `NameTag` component that takes care of creating a sprite with text above the object.

To use, just add `NameTag::new("Ferris".to_string())` as a component to the entity, replacing with the desired name.

The implementation uses old Font code from Bevy that was removed. I don't know if there's a better approach, so if anyone has any suggestions I'd be happy to hear them.

I've also changed the `Camera` to be `CameraRoot`, and I've added a `CameraObject` component to the "actual" camera entity.